### PR TITLE
Update useful-packages.md

### DIFF
--- a/docs/installation/useful-packages.md
+++ b/docs/installation/useful-packages.md
@@ -163,7 +163,7 @@ pacman -S wireless_tools wpa_supplicant ifplugd dialog
 
 ```bash
 pacman -S p7zip unrar unarchiver unzip unace xz rsync
-pacman -S nfs-utils cifs-utils ntfs-3g exfat-utils
+pacman -S nfs-utils cifs-utils ntfs-3g exfat-utils gvfs udisks2
 ```
 
 ## Sound


### PR DESCRIPTION
Adding gvfs and udisks2 to archive and file system utils. Most file managers uses them. It is for mounting Usb drives and such. For those who want a minimal install without full desktop environments.